### PR TITLE
[bt#16913] remove object parameter from ir.values create vals

### DIFF
--- a/mass_editing/models/mass_object.py
+++ b/mass_editing/models/mass_object.py
@@ -95,7 +95,6 @@ class MassObject(orm.Model):
                     'value': (
                         "ir.actions.act_window," +
                         str(vals['ref_ir_act_window'])),
-                    'object': True,
                 },
                 context)
         self.write(


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=helpdesk.ticket&id=16913">[bt#16913] Error, warning in prod log file</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>mass_editing</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->