### PR TITLE
[t141292] avoid m2m multi-company issue

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -385,6 +385,7 @@ class AuditlogRule(models.Model):
                 .with_context(prefetch_fields=False)
                 .read(fields_list)
             }
+            self.invalidate_cache(fields_list, self.ids)
             result = write_full.origin(self, vals, **kwargs)
             new_values = {
                 d["id"]: d


### PR DESCRIPTION
Invalidate cache after calling read method with sudo and before calling write method without sudo

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=141292">[t141292] wrong behaviour of m2m in intercompany</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>auditlog</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->