### PR TITLE
[16.0][IMP] base_view_inheritance_extension: attrs_domain_add

### DIFF
--- a/base_view_inheritance_extension/__manifest__.py
+++ b/base_view_inheritance_extension/__manifest__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Extended view inheritance",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "development_status": "Mature",
     "author": "Therp BV,Odoo Community Association (OCA)",
     "license": "LGPL-3",

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -190,6 +190,42 @@ class IrUiView(models.Model):
         return source
 
     @api.model
+    def inheritance_handler_attributes_attrs_domain_add(self, source, specs):
+        """Implement attrs_domain_add
+
+        <attribute name="$attribute" operation="attrs_domain_add"
+                   key="$attrs_key" join_operator="OR">
+            $domain_to_add_to_attrs_key
+        </attribute>
+        """
+        node = self.locate_node(source, specs)
+        for attribute_node in specs:
+            attribute_name = attribute_node.get("name")
+            key = attribute_node.get("key")
+            join_operator = attribute_node.get("join_operator") or "AND"
+            old_value = node.get(attribute_name) or ""
+            if old_value:
+                old_value = ast.literal_eval(
+                    self.var2str_domain_text(old_value.strip())
+                )
+                old_domain_attrs = old_value.get(key)
+                new_domain = ast.literal_eval(
+                    self.var2str_domain_text(attribute_node.text.strip())
+                )
+                if join_operator == "OR":
+                    new_value = expression.OR([old_domain_attrs, new_domain])
+                else:
+                    new_value = expression.AND([old_domain_attrs, new_domain])
+                old_value[key] = new_value
+                new_value = self.str2var_domain_text(str(old_value))
+            else:
+                # We must ensure that the domain definition has not line breaks because
+                # in update mode the domain cause an invalid syntax error
+                new_value = "{'%s': %s}" % (key, attribute_node.text.strip())
+            node.attrib[attribute_name] = new_value
+        return source
+
+    @api.model
     def var2str_domain_text(self, domain_str):
         """Replaces var names with str names to allow eval without defined vars"""
         # Replace fields in 2 steps because 1 step returns "parent_sufix"."var_sufix"

--- a/base_view_inheritance_extension/readme/CONTRIBUTORS.rst
+++ b/base_view_inheritance_extension/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
   * Carlos Dauden
 
 * Iván Todorovich <ivan.todorovich@camptocamp.com>
+* Carlos Serra-Toro <carlos.serra@braintec.com>

--- a/base_view_inheritance_extension/readme/USAGE.rst
+++ b/base_view_inheritance_extension/readme/USAGE.rst
@@ -31,3 +31,12 @@ to refer to some xmlid, say ``%(xmlid)s``.
                condition="$field_condition" join_operator="OR">
         $domain_to_add
     </attribute>
+
+**Add domain with AND/OR join operator (AND if missed) for key in attrs**
+
+.. code-block:: xml
+
+    <attribute name="$attribute" operation="attrs_domain_add"
+               key="$attrs_key" join_operator="OR">
+        $domain_to_add_to_attrs_key
+    </attribute>


### PR DESCRIPTION
New operation 'attrs_domain_add', used to add a domain to the attribute 'attrs'.